### PR TITLE
Add proper shebang, changed cgi to html in jsontemplate

### DIFF
--- a/CapTipper.py
+++ b/CapTipper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 #          CapTipper is a malicious HTTP traffic explorer tool

--- a/jsontemplate/jsontemplate.py
+++ b/jsontemplate/jsontemplate.py
@@ -38,7 +38,7 @@ import pprint
 import re
 
 # For formatters
-import cgi  # cgi.escape
+import html  # html.escape
 import urllib.request, urllib.parse, urllib.error  # for urllib.encode
 import urllib.parse  # for urljoin
 
@@ -540,7 +540,7 @@ def _ToString(x):
 
 
 def _HtmlAttrValue(x):
-  return cgi.escape(x, quote=True)
+  return html.escape(x, quote=True)
 
 
 def _AbsUrl(relative_url, context, unused_args):
@@ -565,7 +565,7 @@ def _AbsUrl(relative_url, context, unused_args):
 # This is a *public* constant, so that callers can use it construct their own
 # formatter lookup dictionaries, and pass them in to Template.
 _DEFAULT_FORMATTERS = {
-    'html': cgi.escape,
+    'html': html.escape,
 
     # The 'htmltag' name is deprecated.  The html-attr-value name is preferred
     # because it can be read with "as":
@@ -592,7 +592,7 @@ _DEFAULT_FORMATTERS = {
 
     # Just show a plain URL on an HTML page (without anchor text).
     'plain-url': lambda x: '<a href="%s">%s</a>' % (
-        cgi.escape(x, quote=True), cgi.escape(x)),
+        html.escape(x, quote=True), html.escape(x)),
 
     # A context formatter
     'AbsUrl': _AbsUrl,
@@ -824,7 +824,7 @@ def CompileTemplate(
 
     more_formatters:
         Something that can map format strings to formatter functions.  One of:
-          - A plain dictionary of names -> functions  e.g. {'html': cgi.escape}
+          - A plain dictionary of names -> functions  e.g. {'html': html.escape}
           - A higher-order function which takes format strings and returns
             formatter functions.  Useful for when formatters have parsed
             arguments.


### PR DESCRIPTION
Since this is a Python 3 branch, I've added the proper shebang (#!/usr/bin/env python3) to the CapTipper.py file.
Additionally, Python 3.8 cgi no longer has an escape attribute. To make this functional on both Ubuntu 18 (Python 3.6) and Ubuntu 20 (Python3.8) and other OSes, I've changed the cgi.escape calls in jsontemplate.py to html.escape.

